### PR TITLE
Proposal Draft: Support Timestamps and Labels for Individual Events

### DIFF
--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -122,7 +122,7 @@ message Sample {
   // combination with breakdown, the breakdown labels take precedence if
   // there is a key overlap.
   repeated Label label = 3;
-  // Breakdown can hold the individual timestamps and values for a sample that
+  // breakdown can hold the individual timestamps and values for a sample that
   // has aggregated values. The type and unit of each breakdown is defined by
   // the corresponding entry in Profile.sample_type. It's acceptable to have
   // less, but not more, breakdown entries than Profile.sample_type entries.

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -122,35 +122,33 @@ message Sample {
   // combination with breakdown, the breakdown labels take precedence if
   // there is a key overlap.
   repeated Label label = 3;
-  // breakdown can hold the individual timestamps and values for a sample that
-  // has aggregated values. The type and unit of each breakdown is defined by
-  // the corresponding entry in Profile.sample_type. It's acceptable to have
-  // less, but not more, breakdown entries than Profile.sample_type entries.
+  // breakdown can hold the individual timestamps and values for a
+  // sample that represents an aggregation of events. The type and unit
+  // of each breakdown is defined by the corresponding entry in
+  // Profile.sample_type. It's acceptable to have less, but not more,
+  // breakdown entries than Profile.sample_type entries. Put sample
+  // types that don't have breakdown data available at the end of
+  // Profile.sample_type and omit them here to take advantage of this.
   repeated Breakdown breakdown = 4;
 }
 
-// Breakdown stores data about the individual events that have been aggregated
-// into a Sample. There can be one breakdown for each Profile.sample_type.
-//
-// TODO: Figure out if this can also be used for the exemplar UC from alexey:
-// https://github.com/google/pprof/pull/725#issuecomment-1264841904
+// Breakdown stores data about the individual events that have been
+// aggregated into a Sample. There can be one breakdown for each
+// Profile.sample_type.
 message Breakdown {
-  // A list of timestamps at which the values of the associated sample were
-  // collected. The time is given in Profile.tick_unit resolution relative to
-  // Profile.time_nanos and values are delta encoded. So for three events
-  // captured at 100, 110 and 150 ticks after the profile start, this list should
-  // hold the values [100, 10, 40].
-  //
-  // TODO: Is delta encoding going to safe enough space to justify the
-  // complexity?
+  // A list of timestamps at which the values of the associated sample
+  // were collected. The time is given in Profile.tick_unit resolution
+  // relative to Profile.time_nanos.
   repeated int64 ticks = 1;
-  // A list that is either empty or holding exactly the same number of elements
-  // as Breakdown.ticks, associating each point in time with a recorded value.
-  // For cumulative sample types the sum of these values should add up to the
-  // corresponding Sample.value.
+  // A list that is either empty or holding exactly the same number of
+  // elements as Breakdown.ticks, associating each point in time with a
+  // recorded value. For cumulative sample types the sum of these values
+  // should add up to the corresponding Sample.value. Leaving the list
+  // empty makes sense if all events have the same value.
   repeated int64 value = 2;
-  // A list that is either empty or holding exactly the same number of elements
-  // as Breakdown.ticks, associating each point in time with a LabelSet.
+  // A list that is either empty or holding exactly the same number of
+  // elements as Breakdown.ticks, associating each point in time with a
+  // LabelSet.
   repeated uint64 label_set_id = 3;
 }
 

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -149,7 +149,7 @@ message Breakdown {
   repeated int64 value = 2;
   // A list that is either empty or holding exactly the same number of elements
   // as Breakdown.ticks, associating each point in time with a LabelSet.
-  repeated uint64 label_set_id = 1;
+  repeated uint64 label_set_id = 3;
 }
 
 message Label {

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -129,7 +129,7 @@ message Breakdown {
   // profile start, this list should hold the values [3, 1, 2].
   repeated int64 time_offset_nanos = 1;
   // A list that is either empty or holding exactly the same number of elements
-  // as Sample.time_offset_nanos, associating each point in time with a
+  // as Breakdown.time_offset_nanos, associating each point in time with a
   // recorded value. For cumulative sample types the sum of these values should
   // add up to the corresponding Sample.value.
   repeated int64 value = 2;

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -175,7 +175,9 @@ message Label {
 // - Tracing IDs (e.g. trace_id=123, span_id=345)
 // - Thread/Process IDs (e.g. process_id=123, thread_id=456)
 message LabelSet {
-  repeated Label label = 1;
+  // Unique nonzero id for the LabelSet.
+  uint64 id = 1;
+  repeated Label label = 2;
 }
 
 message Mapping {

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -89,6 +89,11 @@ message Profile {
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
+  // Defines the resolution of Breakdown.ticks, e.g. "nanoseconds" or
+  // "microseconds".
+  int64 tick_unit = 15;
+  // Labels referenced by Breakdown.
+  repeated LabelSet label_set = 16;
 }
 
 // ValueType describes the semantics and measurement units of a value.
@@ -122,17 +127,26 @@ message Sample {
   repeated Breakdown breakdown = 4;
 }
 
+// Breakdown stores data about the individual events that have been aggregated
+// into a Sample.
 message Breakdown {
   // A list of timestamps at which the values of the associated sample were
-  // collected. The time is given relative to Profile.time_nanos and values are
-  // delta encoded. So for three events captured at 3, 4 and 6 nsec after the
-  // profile start, this list should hold the values [3, 1, 2].
-  repeated int64 time_offset_nanos = 1;
+  // collected. The time is given in Profile.tick_unit resolution relative to
+  // Profile.time_nanos and values are delta encoded. So for three events
+  // captured at 100, 110 and 150 ticks after the profile start, this list should
+  // hold the values [100, 10, 40].
+  //
+  // TODO: Is delta encoding going to safe enough space to justify the
+  // complexity?
+  repeated int64 ticks = 1;
   // A list that is either empty or holding exactly the same number of elements
-  // as Breakdown.time_offset_nanos, associating each point in time with a
-  // recorded value. For cumulative sample types the sum of these values should
-  // add up to the corresponding Sample.value.
+  // as Breakdown.ticks, associating each point in time with a recorded value.
+  // For cumulative sample types the sum of these values should add up to the
+  // corresponding Sample.value.
   repeated int64 value = 2;
+  // A list that is either empty or holding exactly the same number of elements
+  // as Breakdown.ticks, associating each point in time with a LabelSet.
+  repeated uint64 label_set_id = 1;
 }
 
 message Label {
@@ -150,6 +164,15 @@ message Label {
   // units and units like "seconds" and "nanoseconds" as time units,
   // and apply appropriate unit conversions to these.
   int64 num_unit = 4;  // Index into string table
+}
+
+// A group of labels that can be referenced multiple times in order to reduce
+// overhead. Example use cases for reusable label sets:
+//
+// - Tracing IDs (e.g. trace_id=123, span_id=345)
+// - Thread/Process IDs (e.g. process_id=123, thread_id=456)
+message LabelSet {
+  repeated Label label = 1;
 }
 
 message Mapping {

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -125,7 +125,7 @@ message Sample {
 message Breakdown {
   // A list of timestamps at which the values of the associated sample were
   // collected. The time is given relative to Profile.time_nanos and values are
-  // delta encoded. So for two events captured at 3, 4 and 6 nsec after the
+  // delta encoded. So for three events captured at 3, 4 and 6 nsec after the
   // profile start, this list should hold the values [3, 1, 2].
   repeated int64 time_offset_nanos = 1;
   // A list that is either empty or holding exactly the same number of elements

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -75,7 +75,7 @@ message Profile {
   // The following fields are informational, do not affect
   // interpretation of results.
 
-  // Time of collection (UTC) represented as nanoseconds past the epoch.
+  // Time the collection started (UTC) represented as nanoseconds past the epoch.
   int64 time_nanos = 9;
   // Duration of the profile, if a duration makes sense.
   int64 duration_nanos = 10;
@@ -115,6 +115,24 @@ message Sample {
   // label includes additional context for this sample. It can include
   // things like a thread id, allocation size, etc
   repeated Label label = 3;
+  // Breakdown can hold the individual timestamps and values for a sample that
+  // has aggregated values. The type and unit of each breakdown is defined by
+  // the corresponding entry in Profile.sample_type. It's acceptable to have
+  // less, but not more, breakdown entries than Profile.sample_type entries.
+  repeated Breakdown breakdown = 4;
+}
+
+message Breakdown {
+  // A list of timestamps at which the values of the associated sample were
+  // collected. The time is given relative to Profile.time_nanos and values are
+  // delta encoded. So for two events captured at 3, 4 and 6 nsec after the
+  // profile start, this list should hold the values [3, 1, 2].
+  repeated int64 time_offset_nanos = 1;
+  // A list that is either empty or holding exactly the same number of elements
+  // as Sample.time_offset_nanos, associating each point in time with a
+  // recorded value. For cumulative sample types the sum of these values should
+  // add up to the corresponding Sample.value.
+  repeated int64 value = 2;
 }
 
 message Label {

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -128,7 +128,7 @@ message Sample {
 }
 
 // Breakdown stores data about the individual events that have been aggregated
-// into a Sample.
+// into a Sample. There can be one breakdown for each Profile.sample_type.
 message Breakdown {
   // A list of timestamps at which the values of the associated sample were
   // collected. The time is given in Profile.tick_unit resolution relative to

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -118,7 +118,9 @@ message Sample {
   // lists of the originals.
   repeated int64 value = 2;
   // label includes additional context for this sample. It can include
-  // things like a thread id, allocation size, etc
+  // things like a thread id, allocation size, etc. When using label in
+  // combination with breakdown, the breakdown labels take precedence if
+  // there is a key overlap.
   repeated Label label = 3;
   // Breakdown can hold the individual timestamps and values for a sample that
   // has aggregated values. The type and unit of each breakdown is defined by

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -129,6 +129,9 @@ message Sample {
 
 // Breakdown stores data about the individual events that have been aggregated
 // into a Sample. There can be one breakdown for each Profile.sample_type.
+//
+// TODO: Figure out if this can also be used for the exemplar UC from alexey:
+// https://github.com/google/pprof/pull/725#issuecomment-1264841904
 message Breakdown {
   // A list of timestamps at which the values of the associated sample were
   // collected. The time is given in Profile.tick_unit resolution relative to

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -89,8 +89,8 @@ message Profile {
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
-  // Defines the resolution of Breakdown.ticks, e.g. "nanoseconds" or
-  // "microseconds".
+  // Index into the string table that defines the resolution of
+  // Breakdown.ticks, e.g. "nanoseconds" or "microseconds".
   int64 tick_unit = 15;
   // Labels referenced by Breakdown.
   repeated LabelSet label_set = 16;


### PR DESCRIPTION
# Motivation

My team at Datadog is using pprof as our data collection format for profiling data (cpu, wall clock, lock contention, allocations, etc.) coming from non-JVM languages (which use JFR). This works very well for us, and we'd like to continue building on pprof. However, there are two use cases we are interested in that are currently difficult to implement efficiently using pprof.

This proposal outlines these use cases as well as potential changes to the `profile.proto` format that would support them. We believe that these use cases would also be useful to the OSS community. Additionally the proposal should meet the signal correlation requirements of the [Profiling Vision OTEP](https://github.com/open-telemetry/oteps/blob/main/text/profiles/0212-profiling-vision.md), which might allow pprof to be adopted by OpenTelemtry.

Last, but not least, we hope that this proposal would ease the adoption of these features by the Go runtime, e.g. by adding timestamps to CPU profiles.

## UC 1: Thread Timelines (FlameChart)

We would like to break down the self-time of distributed tracing spans using per-thread (or goroutine) flame chart timelines. The data for this would be collected using wall clock sampling, tracing techniques, or a combination of both. This is similar to what [fgtrace](https://github.com/felixge/fgtrace) does, but would only show the threads relevant to the span:

![image](https://user-images.githubusercontent.com/15000/195843761-1a6e695c-46e6-4d62-a51e-05958f58d214.png)

In order to support this use case, pprof would need the ability to efficiently store timestamps, thread ids and span ids for the individual profiling events that are being recorded. Additionally the pprof UI might be extended to show this data, or the command line could be extended to target [perfetto](https://perfetto.dev/) or other flame chart visualization tools.

## UC 2: CPU Heatmaps (FlameScope)

Another use case we are interested in is the display of of CPU Heatmaps pioneered by [FlameScope](https://www.brendangregg.com/blog/2018-11-08/flamescope-pattern-recognition.html) which provide a more powerful way to understand application behavior.

![image](https://user-images.githubusercontent.com/15000/195847172-46b39ec9-58a6-4b36-b336-e36576585e38.png)

This use case is simpler than the first use case and only requires timestamp information for individual CPU samples. Additionally the UI could add this visualization or the command line could output the data in a format understood by [flamescope](https://github.com/Netflix/flamescope).

# Example

Let's say we have a wallclock profile that contains 3 events:

|time since start|duration|stack trace|trace id|span id|thread id|
|-|-|-|-|-|-|
|10ms|15ms|a;b;c;d;e;f;g;h|1|1|1|
|25ms|5ms|a;b;c;d;e;f;g;h|1|1|1|
|40ms|20ms|a;b;c;d;e;f;g;h|2|2|2|

Note: For the purpose of this example the stack trace is the same for all 3 events.

How could this data be encoded into pprof?

## Using Labels (Today)

With the existing `profile.proto`, one may use labels to store the data like this (shown in pseudo pprof format):

```
sample_type: [walltime/nanoseconds]

sample {
  location_id: a
  location_id: b
  location_id: c
  location_id: d
  location_id: e
  location_id: f
  location_id: g
  location_id: h
  value: 1500000000
  label: {time_ms=10}
  label: {trace_id=1}
  label: {span_id=1}
  label: {thread_id=1}
}

sample {
  location_id: a
  location_id: b
  location_id: c
  location_id: d
  location_id: e
  location_id: f
  location_id: g
  location_id: h
  value: 500000000
  label: {time_ms=25}
  label: {trace_id=1}
  label: {span_id=1}
  label: {thread_id=1}
}

sample {
  location_id: a
  location_id: b
  location_id: c
  location_id: d
  location_id: e
  location_id: f
  location_id: g
  location_id: h
  value: 2000000000
  label: {time_ms=40}
  label: {trace_id=2}
  label: {span_id=2}
  label: {thread_id=2}
}
```

Unfortunately this requires to encode the location_id list three times b/c the `Sample` message has no concept of referencing a stack trace by id and each unique combination of labels requires us to have its own `Sample`. In practice this leads to very large pprof files.

## Using Breakdown (Proposed Change)

Using the proposed `profile.proto` change in this PR, the same data could be encoded like shown below. In practice, this should lead to much smaller pprof sizes.

```
sample_type: [walltime/nanoseconds]
tick_unit: ms

sample {
  location_id: a
  location_id: b
  location_id: c
  location_id: d
  location_id: e
  location_id: f
  location_id: g
  location_id: h
  value: 3000000000
  breakdown: {
    tick: 10
    tick: 25
    tick: 40
    value: 15
    value: 5
    value: 20,
    label_set_id: 1
    label_set_id: 1
    label_set_id: 2
  }
}

labelSet {
  id: 1
  label: {trace_id=1}
  label: {span_id=1}
  label: {thread_id=1}
}

LabelSet 2 {
  id: 2
  label: {trace_id=2}
  label: {span_id=2}
  label: {thread_id=2}
}
```

# Efficiency

This proposal can lead to significant size reduction of **uncompressed pprofs** compared to using the existing label mechanism when adding timestamps and trace ids. Workloads with less unique stack traces and longer profiling periods gain the most benefits from this proposal. E.g. in the examples below the gains are from 1.4x to 3.2x, but it's possible to construct examples that see bigger or smaller improvements.

That being said, the benefits mostly disappear after **gzip compression**. E.g. the same examples see only 1.01x to 1.22x compression gains. This is perhaps not surprising given that the duplicated stack traces are easy targets for compression.

For more details see [felixge/pprof-breakdown](https://github.com/felixge/pprof-breakdown) and [raw results (spreadsheet)](https://docs.google.com/spreadsheets/d/158gORmju85Z1rwGtTEL71yrkmLHQw4KGPMYKrHfm8qU/edit?usp=sharing).

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/15000/196993697-b94fed9c-cde0-4669-a935-9e509856bb9f.png">

# Compatibility

The proposed change is fully backwards compatible, but not fully forwards compatible when it comes to labels. The new format puts event specific labels into the new `Breakdown` message. This means that profiles taking advantage of the new `profile.proto` Breakdown labels won't be completely accessible to old versions of the pprof tool or other tools consuming pprof information. Those tools could still render basic flame graphs, but the label information would be invisible to them.

# Next Steps

We're looking for feedback from the pprof maintainers to understand if "Support Timestamps and Labels for Individual Events" is a compelling feature or if the pprof project would rather stay focused on storing pre-aggregated data. Our suggest changes to `profile.proto` should mostly be seen as a demonstration of the technical feasibility of implementing such a proposal, but we're not too attached to the implementation details and happy to adjust them as needed. Perhaps the small gains on compressed pprofs are not sufficient justification for the added complexity, and a simpler proposal to standardize the usage of the existing label mechanism for the use cases outlined above would offer better tradeoffs.

Additionally we'd like to get feedback from the OSS community and potentially OTel group to make sure the outlined use cases are clear and useful to others.